### PR TITLE
Update RetrainerLib.cs

### DIFF
--- a/MLRetrainerLib/RetrainerLib.cs
+++ b/MLRetrainerLib/RetrainerLib.cs
@@ -683,7 +683,7 @@ namespace MLRetrainerLib
             {
                 return false;
             }
-            if (lastScores == null) { return true;
+            if (lastScores == null || lastScores.Count == 0) { return true;
             }
             bool isImproved = false;
 


### PR DESCRIPTION
When no prior training results, the lastScores attribute returns a count 0 instead of null.
